### PR TITLE
No priorities

### DIFF
--- a/data/acl.sql
+++ b/data/acl.sql
@@ -3,14 +3,13 @@
 create table access_role (
   role      nvarchar(64) not null collate utf8_general_ci,
   parent    nvarchar(64)     null collate utf8_general_ci,
-  priority  integer,
   role_type nvarchar(32) not null collate utf8_general_ci
 ) ENGINE=InnoDB;
 
 -- Inbuilt default roles (do not delete).
-insert into access_role (role, parent, priority, role_type) values ('guest', null, 0, 'Built in role.');
-insert into access_role (role, parent, priority, role_type) values ('user', 'guest', 1, 'Built in role.');
-insert into access_role (role, parent, priority, role_type) values ('admin', 'user', 2, 'Built in role.');
+insert into access_role (role, parent, priority, role_type) values ('guest', null, 'Built in role.');
+insert into access_role (role, parent, priority, role_type) values ('user', 'guest', 'Built in role.');
+insert into access_role (role, parent, priority, role_type) values ('admin', 'user', 'Built in role.');
 
 -- Rule table.
 create table access_rule (

--- a/data/create_admin.sql.sql
+++ b/data/create_admin.sql.sql
@@ -1,3 +1,3 @@
 -- Create initial admin user
-insert into access_role(role, parent, priority, role_type)
-values(1, 'admin', 4, 'User Role');
+insert into access_role(role, parent, role_type)
+values(1, 'admin', 'User Role');

--- a/src/CivAccess/Acl/Role.php
+++ b/src/CivAccess/Acl/Role.php
@@ -6,7 +6,6 @@ class Role implements RoleInterface
 {
     protected $role;
     protected $parent;
-    protected $priority;
     protected $roleType;
     
     public function getRole()
@@ -28,17 +27,6 @@ class Role implements RoleInterface
     public function setParent($parent)
     {
         $this->parent = $parent;
-        return $this;
-    }
-    
-    public function getPriority()
-    {
-        return $this->priority;
-    }
-    
-    public function setPriority($priority)
-    {
-        $this->priority = $priority;
         return $this;
     }
     

--- a/src/CivAccess/Acl/RoleInterface.php
+++ b/src/CivAccess/Acl/RoleInterface.php
@@ -8,6 +8,6 @@ interface RoleInterface
     public function setRole($role);
     public function getParent();
     public function setParent($parent);
-    public function getPriority();
-    public function setPriority($priority);
+    public function getRoleType();
+    public function setRoleType($roleType);
 }

--- a/src/CivAccess/Mapper/RoleMapper.php
+++ b/src/CivAccess/Mapper/RoleMapper.php
@@ -16,7 +16,6 @@ class RoleMapper extends AbstractDbMapper implements DbAdapterAwareInterface
         if (null != $where){
             $select->where($where);
         }
-        $select->order(array('priority', 'role'));
         return $this->select($select);
     }
     

--- a/src/CivAccess/Service/AclService.php
+++ b/src/CivAccess/Service/AclService.php
@@ -40,7 +40,6 @@ class AclService
         $roleEntity = new Role();
         $roleEntity->setRole($role)
                    ->setParent($parent)
-                   ->setPriority(4)
                    ->setRoleType('User role.');
         $this->roleMapper->persistRole($roleEntity);
     }
@@ -109,7 +108,7 @@ class AclService
     public function getRoles()
     {
         // Exclude user roles.
-        $where = 'priority <> 4';
+        $where = "role_type <> 'User role.'";
         return $this->roleMapper->getRoles($where);
     }
     

--- a/src/CivAccess/Service/AclService.php
+++ b/src/CivAccess/Service/AclService.php
@@ -57,43 +57,47 @@ class AclService
         } 
     }
     
-    private function loadRoles()
-    {  
-        $previousRole = '';
-        $parents = array();
+    public function loadRoles()
+    {
+        $map = array();
         
         $roles = $this->roleMapper->getRoles();
-        foreach($roles as $current)
+        foreach($roles as $role)
         {
-            $currentRole   = $current->getRole();
-            $currentParent = $current->getParent();
-                   
-            if (($currentRole != $previousRole) && ($previousRole != '')){
-                            
-                // Push the previous role onto the acl.
-                if (empty($parents)){
-                    $parents = null;
+            $roleName = $role->getRole();
+            $parentName = $role->getParent();
+            
+            if (key_exists($roleName, $map)) {
+                if (null != $parentName) {
+                    array_push($map[$roleName], $parentName);
                 }
-                $this->acl->addRole(new GenericRole($previousRole), $parents);
-                $parents = array();
-                
+            } else {
+                $map[$roleName] = (null != $parentName ? array($parentName) : null);
             }
-            
-            if (null != $currentParent){
-                array_push($parents, $currentParent);
+        }
+        foreach($map as $role => $parents) {
+            $this->loadRole($map, $role, $parents);
+        }
+    }
+    
+    private function loadRole($map, $role, $parents)
+    {
+        // Check parents are loaded
+        if (null != $parents) {
+            foreach($parents as $parent)
+            {
+                if (!$this->acl->hasRole($parent)) {
+                    $r = $parent;
+                    $p = $map[$parent];
+                    $this->loadRole($map, $r, $p);
+                }
             }
-            
-            $previousRole = $currentRole;
         }
         
-        if ($previousRole != ''){
-                
-            // Push the previous role onto the acl.
-            if (empty($parents)){
-                $parents = null;
-            }
-            $this->acl->addRole(new GenericRole($previousRole), $parents);
-            $parents = array();
+        // load the role
+        if (!$this->acl->hasRole($role)) {
+            $genericRole = new GenericRole($role);
+            $this->acl->addRole($genericRole, $parents);
         }
     }
     

--- a/view/error/403.phtml
+++ b/view/error/403.phtml
@@ -1,8 +1,6 @@
 <h1>A 403 Error occured</h1>
 <h2>Access Denied</h2>
 
-
-
 <h3>Exception info</h3>
 Role: <?php echo $this->role; ?><br>
 Resource: <?php echo $this->resource; ?><br>


### PR DESCRIPTION
Improved the way roles get loaded into the ACL, so that priorities are no longer required to load roles in a specific order.

Priorities then become obsolete and have been removed.

This will make it easier to add new roles without the need to worry about priorities or the order of loading into the ACL.
